### PR TITLE
Optional custom readings title

### DIFF
--- a/MMM-FHEM.js
+++ b/MMM-FHEM.js
@@ -23,7 +23,7 @@ Module.register('MMM-FHEM', {
 
   // Define required scripts.
   getStyles: function () {
-    return ['MMM-FHEM.css'];
+    return ['MMM-FHEM.css','font-awesome.css','weather-icons.css'];
   },
 
   // Override socket notification handler.

--- a/MMM-FHEM.js
+++ b/MMM-FHEM.js
@@ -17,6 +17,8 @@ Module.register('MMM-FHEM', {
     port: '8083',
     initialLoadDelay: 1000,
     updateInterval: 1 * 60 * 1000, // every 1 minutes
+    title: null,
+    titleSuffix: '',
   },
 
   // Define required scripts.
@@ -77,7 +79,11 @@ Module.register('MMM-FHEM', {
 
       // add device alias/name
       var titleWrapper = document.createElement('div');
-      titleWrapper.innerHTML = device.name;
+      if (self.config.title == null) {
+        titleWrapper.innerHTML = device.name + self.config.titleSuffix;
+      } else {
+        titleWrapper.innerHTML = self.config.title;
+      }
       titleWrapper.className = 'title';
       deviceWrapper.appendChild(titleWrapper);
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,28 @@ The following properties can be configured:
 		</tr>
 
     <tr>
+			<td><code>title</code></td>
+			<td>Optionally replace the title (device name or alias) fetched from FHEM.
+        <br>
+        <br>
+        <b>Possible values:</b> any text
+        <br>
+				<b>Default value:</b> <code>null</code> (use data from FHEM)
+			</td>
+		</tr>
+
+    <tr>
+			<td><code>titleSuffix</code></td>
+			<td>Text to be inserted after the title.
+        <br>
+        <br>
+        <b>Possible values:</b> any text
+        <br>
+				<b>Default value: no suffix
+			</td>
+		</tr>
+
+    <tr>
 			<td><code>devices</code></td>
 			<td>Array of objects.
         <br>


### PR DESCRIPTION
I had a readings alias used somewhere else, which was inconvinient for MM. So I added an option for a configurable readings title. If the option is not used, behavior is as it was, with option `title`, it gets replaced by the configured string.

Since, if displayed side by side, the default title from FHEM was in front of the readings without any space in between, I also added an option `titleSuffix` to add ie. a non breaking space.

And btw. I added the CSS for fontawesome and weather icons. If no other module uses them, they were not available and no icons appeared.